### PR TITLE
Correct Username in git clone Command (Issue #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To set up SereniFi on your local machine, follow these steps:
 
 1. **Clone the Repository**  
    ```bash
-   git clone https://github.com/your-username/serenity-guide.git
+   git clone https://github.com/Amna-Hassan04/serenity-guide.git
    ```
 
 2. **Navigate to the Project Directory**  


### PR DESCRIPTION
This pull request addresses issue #33 by correcting the username in the git clone command within the README file. The previous command used the placeholder your-username, which should be replaced with the actual username of the repository owner.

By making this change, users will be able to successfully clone the repository and access its contents.

<h3>Changes:</h3>

Replaced your-username with the correct username in the git clone command.

Verification:
I have verified that the corrected command works as expected by cloning the repository using the updated command.

<h3>Additional Notes:</h3>

This change is crucial for ensuring that users can properly clone and contribute to the project.

Please let me know if you have any further questions or require additional information.